### PR TITLE
Fixed CPU icon

### DIFF
--- a/.config/eww/yuck/widgets/sysprogress.yuck
+++ b/.config/eww/yuck/widgets/sysprogress.yuck
@@ -18,7 +18,7 @@
     :css "cpu"
     :tip "CPU ${round(EWW_CPU.avg,0)}%"
     :data {EWW_CPU.avg}
-    :icon "﬙"))
+    :icon "󰻠"))
 
 (defwidget sysprogress_ram [] (sysprogress
     :css "ram"


### PR DESCRIPTION
Fixed CPU icon because current font packages could not render it. The applied icon comes from Material Fonts: https://pictogrammers.com/library/mdi/icon/cpu-64-bit/