### PR TITLE
Removed distrobox command from Print keybinding

### DIFF
--- a/.config/hypr/binds.conf
+++ b/.config/hypr/binds.conf
@@ -2,8 +2,8 @@
 bind = CTRL SHIFT, R, exec, bash ~/.config/eww/scripts/init
 
 # Print
-bind = , Print,exec, distrobox-enter -n Arch -- hyprshot -m region -o $HOME/Pictures/Screenshots
-bind = SHIFT, Print,exec, distrobox-enter -n Arch -- hyprshot -m output -o $HOME/Pictures/Screenshots
+bind = , Print,exec, hyprshot -m region -o $HOME/Pictures/Screenshots
+bind = SHIFT, Print,exec, hyprshot -m output -o $HOME/Pictures/Screenshots
 
 # Lid
 bindl= , switch:on:Lid Switch, exec, bash ~/.config/eww/scripts/launcher screenlock


### PR DESCRIPTION
With the current keybinding using distrobox, the keybinding cannot work because distrobox needs of docker to be installed and the user won't be aware about it. Furthermore, distrobox need that the Arch container is pulled and docker daemon will run. My correction removes distrobox (and all this additional steps) and uses directly `hyprshot`. In this manner, a new user using this hyprland config can directly print the screen without additional configuration.