### PR TITLE
Fixed two bugs relating to the screenshot notification

### DIFF
--- a/ags/service/screenrecord.ts
+++ b/ags/service/screenrecord.ts
@@ -75,13 +75,13 @@ class Recorder extends Service {
         Utils.notify({
             image: file,
             summary: "Screenshot",
-            body: this.#file,
+            body: file,
             actions: {
                 "Show in Files": () => sh(`xdg-open ${this.#screenshots}`),
                 "View": () => sh(`xdg-open ${file}`),
                 "Edit": () => {
                     if (dependencies("swappy"))
-                        sh(`swappy, -f ${file}`)
+                        sh(`swappy -f ${file}`)
                 },
             },
         })


### PR DESCRIPTION
1. Swappy image editor was not being launched when Edit button was pressed.

It was due to an unnecessary comma in the sh() function, perhaps intended to separate arguments, but nevertheless was improperly placed.

2. Screenshot notifications were not displaying the file path although it was intended to do so. Also if a screen recording was made, subsequent screenshots would show the last recorded file's path as the path in the screenshot notification.

To fix this, I set notification summary to `file` instead of `this.#file`, which is only set by the screen recorder.