### PR TITLE
made network, taskbar scrollable to avoid UI issues

### DIFF
--- a/ags/widget/bar/Bar.ts
+++ b/ags/widget/bar/Bar.ts
@@ -26,7 +26,12 @@ const widget = {
     powermenu: PowerMenu,
     systray: SysTray,
     system: SystemIndicators,
-    taskbar: Taskbar,
+    taskbar: () => Widget.Scrollable({
+        hscroll: "automatic",
+        vscroll: "never",
+        setup: self => self.set_size_request(500, -1), // set minimum height to 300px
+        child: Taskbar(),
+    }),
     workspaces: Workspaces,
     screenrecord: ScreenRecord,
     messages: Messages,

--- a/ags/widget/quicksettings/widgets/Network.ts
+++ b/ags/widget/quicksettings/widgets/Network.ts
@@ -21,33 +21,6 @@ export const WifiSelection = () => Menu({
     icon: wifi.bind("icon_name"),
     title: "Wifi Selection",
     content: [
-        Widget.Box({
-            vertical: true,
-            setup: self => self.hook(wifi, () => self.children =
-                wifi.access_points.map(ap => Widget.Button({
-                    on_clicked: () => {
-                        if (dependencies("nmcli"))
-                            Utils.execAsync(`nmcli device wifi connect ${ap.bssid}`)
-                    },
-                    child: Widget.Box({
-                        children: [
-                            Widget.Icon(ap.iconName),
-                            Widget.Label(ap.ssid || ""),
-                            Widget.Icon({
-                                icon: icons.ui.tick,
-                                hexpand: true,
-                                hpack: "end",
-                                setup: self => Utils.idle(() => {
-                                    if (!self.is_destroyed)
-                                        self.visible = ap.active
-                                }),
-                            }),
-                        ],
-                    }),
-                })),
-            ),
-        }),
-        Widget.Separator(),
         Widget.Button({
             on_clicked: () => sh(options.quicksettings.networkSettings.value),
             child: Widget.Box({
@@ -55,6 +28,41 @@ export const WifiSelection = () => Menu({
                     Widget.Icon(icons.ui.settings),
                     Widget.Label("Network"),
                 ],
+            }),
+        }),
+        Widget.Separator(),
+        Widget.Scrollable({
+            hscroll: "never",
+            vscroll: "automatic",
+            setup: self => self.set_size_request(-1, 300), // set minimum width and height
+            child: Widget.Box({
+                vertical: true,
+                setup: self => self.hook(wifi, () => self.children =
+                    wifi.access_points
+                        .filter((ap, index, self) =>
+                            index === self.findIndex(elem => (elem.ssid === ap.ssid)))
+                        .map(ap => Widget.Button({
+                            on_clicked: () => {
+                                if (dependencies("nmcli"))
+                                    Utils.execAsync(`nmcli device wifi connect ${ap.bssid}`)
+                            },
+                            child: Widget.Box({
+                                children: [
+                                    Widget.Icon(ap.iconName),
+                                    Widget.Label(ap.ssid || ""),
+                                    Widget.Icon({
+                                        icon: icons.ui.tick,
+                                        hexpand: true,
+                                        hpack: "end",
+                                        setup: self => Utils.idle(() => {
+                                            if (!self.is_destroyed)
+                                                self.visible = ap.active
+                                        }),
+                                    }),
+                                ],
+                            }),
+                        })),
+                ),
             }),
         }),
     ],


### PR DESCRIPTION
The Network options in Quicksettings were sometimes goes out of screen due to more quantity, so made that part scrollable, also same issue happens in Bar, where due to taskbar, if more running apps are there, it makes central part push towards end and stretching more makes end part go out of screen. 

These 2 issues were fixed here   