### PR TITLE
Fix the bluetooth label jumping down when clicked

### DIFF
--- a/ags/style/widgets/bar.scss
+++ b/ags/style/widgets/bar.scss
@@ -121,14 +121,19 @@ $button-radius: $radius;
         @include spacing($spacing: if($bar-spacing==0, $padding / 2, $bar-spacing));
     }
 
+    .quicksettings > bluetooth {
+        label {
+           font-size: $font-size * .7;
+           text-shadow: $text-shadow;
+        }
+    }
+    
     .quicksettings:not(.active):not(:active) {
         .bluetooth {
             color: $primary-bg;
 
             label {
-                font-size: $font-size * .7;
                 color: $fg;
-                text-shadow: $text-shadow;
             }
         }
     }


### PR DESCRIPTION
I noticed that if you have bluetooth devices, and you click on the bluetooth quicksettings button, then the number of connected devices jumps down to fullsize until the item is inactive. 
This seems unintentional, so I've moved out that logic away from the `:active` selector.

Before:
![image](https://github.com/user-attachments/assets/b0cbdf28-8340-4aaf-8483-32ce71f33821)
After:
![image](https://github.com/user-attachments/assets/551d354d-b08b-49b5-a056-67976eb190da)
