### PR TITLE
Fixed application launcher not suggesting packages through :nx anymore

### DIFF
--- a/ags/service/nix.ts
+++ b/ags/service/nix.ts
@@ -86,7 +86,7 @@ class Nix extends Service {
         this.ready = false
         this.#db = {}
 
-        const search = await bash(`nix search ${nixpkgs} --json`)
+        const search = await bash(`nix search ${nixpkgs} --json ^`)
         if (!search) {
             this.ready = true
             return


### PR DESCRIPTION
With changes to `nix search`, the current implementation of the :nx shortcut in the application launcher no longer suggests packages.  This is fixed by using the '^' argument as recommended by the nix search command.